### PR TITLE
Add audio delay setting through cli

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -977,6 +977,11 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             val pos = extras.getInt("position", 0) / 1000f
             onloadCommands.add(arrayOf("set", "start", pos.toString()))
         }
+        //audio delay is in ms
+        if (extras.getInt("audio_delay_ms", 0) != 0) {
+            val delay = extras.getInt("audio_delay", 0) / 1000f
+            onloadCommands.add(arrayOf("set", "audio-delay", delay.toString()))
+        }
     }
 
     // UI (Part 2)


### PR DESCRIPTION
Add audio delay in cli. The delay value is in ms.
For accessing storage: `adb shell pm grant is.xyz.mpv android.permission.READ_EXTERNAL_STORAGE` 

`am start -a android.intent.action.VIEW -t video/any -p is.xyz.mpv -d "http://pricom.com.au/CutestLittleVegetarian.mp4"  --ei "audio_delay_ms" 2000
`

This eventually sets `--audio-delay 2` to mpv. [set](https://l.facebook.com/l.php?u=https%3A%2F%2Fmpv.io%2Fmanual%2Fmaster%2F%3Ffbclid%3DIwAR37GNXTvYtGUYDWfd2E9E3zT_sV8xvKsoXTCM7zniXEckX2ja5KtcFCWyE%23command-interface-set-%253Cname%253E-%253Cvalue%253E&h=AT3HJst0IHSZ7ekxd2P9Ybp7E0o7tR7l43EFfjxe_g7dPOKB8y9PpjDjhv1evz10vTbPBxjmYatvxaTdVABvUfjSV6gtm7PflBjx8oJUbNN-MfV1HPOZdOBVFCowYDNpkFb90LzGlTTXD5DBQGcOldveVpc) is a input command, [--audio-delay](https://l.facebook.com/l.php?u=https%3A%2F%2Fmpv.io%2Fmanual%2Fmaster%2F%3Ffbclid%3DIwAR37GNXTvYtGUYDWfd2E9E3zT_sV8xvKsoXTCM7zniXEckX2ja5KtcFCWyE%23options-audio-delay&h=AT3HJst0IHSZ7ekxd2P9Ybp7E0o7tR7l43EFfjxe_g7dPOKB8y9PpjDjhv1evz10vTbPBxjmYatvxaTdVABvUfjSV6gtm7PflBjx8oJUbNN-MfV1HPOZdOBVFCowYDNpkFb90LzGlTTXD5DBQGcOldveVpc) is one of the options, which takes value in second.

`value <0 means: audio ahead`
`value >0 means: audio delay`